### PR TITLE
Updated fix_deposit documentation

### DIFF
--- a/doc/src/fix_deposit.rst
+++ b/doc/src/fix_deposit.rst
@@ -220,11 +220,11 @@ ignored if the *global* or *local* keywords are used, since those
 options choose a z-coordinate for insertion independently.
 
 The vx, vy, and vz components of velocity for the inserted particle
-are set using the values specified for the *vx*, *vy*, and *vz*
-keywords.  Note that normally, new particles should be a assigned a
-negative vertical velocity so that they move towards the surface.  For
-molecules, the same velocity is given to every particle (no rotation
-or bond vibration).
+are set by sampling a uniform distribution between the bounds set by
+the values specified for the *vx*, *vy*, and *vz* keywords. Note that 
+normally, new particles should be a assigned a negative vertical 
+velocity so that they move towards the surface.  For molecules, the 
+same velocity is given to every particle (no rotation or bond vibration).
 
 If the *target* option is used, the velocity vector of the inserted
 particle is changed so that it points from the insertion position


### PR DESCRIPTION
**Summary**

Updated fix_deposit documentation to specify the distribution that is sampled between the low and high bounds the user provides for each velocity component.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system

